### PR TITLE
Basic example of application packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,53 @@ This template will bootstrap a new spark project with everyone's "favourite" wor
 
 To encourage good software development practice, this starts with a project at 100% code coverage (e.g. one test :p), while its expected for this to decrease, we hope you use the provided [spark-testing-base][stb] library or similar option.
 
-## Using
+## Creating a new project from this template
 
 Have g8 installed? You can run it with:
+
 ```bash
-g8  holdenk/sparkProjectTemplate --name=projectname --organization=com.my.org --sparkVersion=2.2.0
+g8 holdenk/sparkProjectTemplate --name=projectname --organization=com.my.org --sparkVersion=2.2.0
 ```
 
 Using sbt (0.13.13+)? just do
+
 ```bash
-sbt new holdenk/sparkProjectTemplate
+sbt new holdenk/sparkProjectTemplate.g8
 ```
+
+## Executing the created project
+
+First go to the project you created: 
+
+```bash
+cd projectname
+```
+
+You can test locally the example spark job included in this template directly from sbt: 
+
+```bash 
+sbt "run inputFile.txt outputFile.txt"
+```
+
+then choose `CountingLocalApp` when prompted.
+
+You can also assemble a fat jar (see [sbt-assembly](https://github.com/sbt/sbt-assembly) for configuration details): 
+
+```bash
+sbt assembly
+```
+
+then [submit as usual](https://spark.apache.org/docs/latest/submitting-applications.html) to your spark cluster :
+
+```bash
+/path/to/spark-home/bin/spark-submit \
+  --class <package-name>.CountingApp \
+  --name the_awesome_app \
+  --master <master url> \
+  ./target/scala-2.11/<jar name> \
+  <input file> <output file>
+```
+
 
 ## Related
 

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -8,7 +8,10 @@ lazy val root = (project in file(".")).
       scalaVersion := "2.11.8"
     )),
     name := "$name$",
-    version := "0.0.1",
+    version := "$version$",
+
+    sparkVersion := "$sparkVersion$",
+    sparkComponents := Seq(),
 
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled"),

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -20,11 +20,15 @@ lazy val root = (project in file(".")).
 
     libraryDependencies ++= Seq(
       "org.apache.spark" %% "spark-streaming" % "$sparkVersion$" % "provided",
+      "org.apache.spark" %% "spark-sql" % "2.2.0" % "provided",
 
       "org.scalatest" %% "scalatest" % "3.0.1" % "test",
       "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
       "com.holdenkarau" %% "spark-testing-base" % "$sparkVersion$_$sparkTestingbaseRelease$" % "test" 
     ),
+
+    // uses compile classpath for the run task, including "provided" jar (cf http://stackoverflow.com/a/21803413/3827)
+    run in Compile := Defaults.runTask(fullClasspath in Compile, mainClass in (Compile, run), runner in (Compile, run)).evaluated,
 
    resolvers ++= Seq(
       "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/",

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -1,5 +1,7 @@
 // give the user a nice default project!
+
 lazy val root = (project in file(".")).
+
   settings(
     inThisBuild(List(
       organization := "$organization$",
@@ -7,26 +9,32 @@ lazy val root = (project in file(".")).
     )),
     name := "$name$",
     version := "0.0.1",
-    sparkVersion := "$sparkVersion$",
+
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-    sparkComponents := Seq("core", "sql", "catalyst", "mllib"),
+    javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled"),
+    scalacOptions ++= Seq("-deprecation", "-unchecked"),
     parallelExecution in Test := false,
     fork := true,
+
     coverageHighlighting := true,
-    javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled"),
+
     libraryDependencies ++= Seq(
-      // Test your code PLEASE!!!
+      "org.apache.spark" %% "spark-streaming" % "$sparkVersion$" % "provided",
+
       "org.scalatest" %% "scalatest" % "3.0.1" % "test",
       "org.scalacheck" %% "scalacheck" % "1.13.4" % "test",
-      "com.holdenkarau" %% "spark-testing-base" % "$sparkVersion$_$sparkTestingbaseRelease$") % "test",
-   scalacOptions ++= Seq("-deprecation", "-unchecked"),
-    pomIncludeRepository := { x => false },
-    resolvers ++= Seq(
+      "com.holdenkarau" %% "spark-testing-base" % "$sparkVersion$_$sparkTestingbaseRelease$" % "test" 
+    ),
+
+   resolvers ++= Seq(
       "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/",
       "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/",
       "Second Typesafe repo" at "http://repo.typesafe.com/typesafe/maven-releases/",
       Resolver.sonatypeRepo("public")
     ),
+
+    pomIncludeRepository := { x => false },
+
     // publish settings
     publishTo := {
       val nexus = "https://oss.sonatype.org/"

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -2,6 +2,8 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -2,6 +2,10 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
+resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+
+addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")
+
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")

--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -2,10 +2,6 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
-
-addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.5")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")

--- a/src/main/g8/src/main/scala/$package__packaged$/CountingApp.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/CountingApp.scala
@@ -1,0 +1,36 @@
+package $organization$.$name$
+
+import org.apache.spark.{SparkConf, SparkContext}
+
+/**
+  * Use this to test the app locally, from sbt:
+  * sbt "run inputFile.txt outputFile.txt"
+  *  (+ select CountingLocalApp when prompted)
+  */
+object CountingLocalApp extends App{
+  val (inputFile, outputFile) = (args(0), args(1))
+  val conf = new SparkConf()
+    .setMaster("local")
+    .setAppName("my awesome app")
+
+  Runner.run(conf, inputFile, outputFile)
+}
+
+/**
+  * Use this when submitting the app to a cluster with spark-submit
+  * */
+object CountingApp extends App{
+  val (inputFile, outputFile) = (args(0), args(1))
+
+  // spark-submit command should supply all necessary config elements
+  Runner.run(new SparkConf(), inputFile, outputFile)
+}
+
+object Runner {
+  def run(conf: SparkConf, inputFile: String, outputFile: String): Unit = {
+    val sc = new SparkContext(conf)
+    val rdd = sc.textFile(inputFile)
+    val counts = WordCount.withStopWordsFiltered(rdd)
+    counts.saveAsTextFile(outputFile)
+  }
+}


### PR DESCRIPTION
Hi, 

I added a basic example of a scala application that wraps `WordCount`.

I also provided instructions in the README regarding how to launch that application directly from `sbt` as well as how to package it as a "fat-jar" that can be sent to a spark master through `spark-submit`. 

In the process I removed the dependency towards spark through the `sbt-spark-package` and replaced them by explicit dependencies as `libraryDependencies`. This allows me to mark the jars as `provided` so they are not included in the fat-jar. I think there is more control that way, especially if exclusion rules start to be necessary for the packaging. 

I hope you find that interesting :) 

Any feed-back welcome, 

Svend
