### PR TITLE
README changes for usage with `sbt new` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Have g8 installed? You can run it with:
 g8  holdenk/sparkProjectTemplate --name=projectname --organization=com.my.org --sparkVersion=2.2.0
 ```
 
-Using sbt (0.13.13+)? just do
+Using sbt (0.13.13+) just do
 ```bash
 sbt new holdenk/sparkProjectTemplate.g8
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ g8  holdenk/sparkProjectTemplate --name=projectname --organization=com.my.org --
 
 Using sbt (0.13.13+)? just do
 ```bash
-sbt new holdenk/sparkProjectTemplate
+sbt new holdenk/sparkProjectTemplate.g8
 ```
 
 ## Related


### PR DESCRIPTION
1. Fix project name by adding `.g8` suffix. Resulted in `Template not found` error otherwise.
2. Clarified that it was indeed sbt 0.13.13 that introduced `sbt new`