### PR TITLE
Update new template format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ g8  holdenk/sparkProjectTemplate --name=projectname --organization=com.my.org --
 
 Using sbt (0.13.13+)? just do
 ```bash
-sbt new holdenk/sparkProjectTemplate
+sbt new holdenk/sparkProjectTemplate.g8
 ```
 
 ## Related


### PR DESCRIPTION
Getting

```
thomas@work$ sbt new holdenk/sparkProjectTemplate
[info] Set current project to work (in build file:/Users/thomas/work/)
Template not found for: holdenk/sparkProjectTemplate
```

When I add the .g8 it works.

```
thomas@work$ sbt new holdenk/sparkProjectTemplate.g8
[info] Set current project to work (in build file:/Users/thomas/work/)

This is a g8 template for building a skeleton Spark project.
```

Using sbt 1.0

```
thomas@work$ sbt about
[warn] No sbt.version set in project/build.properties, base directory: /Users/thomas/work
[info] Set current project to work (in build file:/Users/thomas/work/)
[info] This is sbt 1.0.2
[info] The current project is {file:/Users/thomas/work/}work 0.1-SNAPSHOT
[info] The current project is built against Scala 2.12.3
[info] Available Plugins: sbt.plugins.IvyPlugin, sbt.plugins.JvmPlugin, sbt.plugins.CorePlugin, sbt.plugins.JUnitXmlReportPlugin, sbt.plugins.Giter8TemplatePlugin
[info] sbt, sbt plugins, and build definitions are using Scala 2.12.3
```