### PR TITLE
Update spark package to fix sbt-spark-package download

### DIFF
--- a/src/main/g8/project/plugins.sbt
+++ b/src/main/g8/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 
-resolvers += "Spark Package Main Repo" at "https://dl.bintray.com/spark-packages/maven"
+resolvers += "spark-packages" at "https://repos.spark-packages.org/"
 
 addSbtPlugin("org.spark-packages" % "sbt-spark-package" % "0.2.6")
 


### PR DESCRIPTION
When created a template with the template, sbt was not able to locate sbt-spark-package.
By looking at its git issue found the solution. https://github.com/databricks/sbt-spark-package/issues/47

