### PR TITLE
Removed -XX:MaxPermSize=2048M and -XX:+CMSClassUnloadingEnabled

### DIFF
--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -15,7 +15,7 @@ lazy val root = (project in file(".")).
     sparkVersion := "$sparkVersion$",
 
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
-    javaOptions ++= Seq("-Xms512M", "-Xmx2048M", "-XX:MaxPermSize=2048M", "-XX:+CMSClassUnloadingEnabled"),
+    javaOptions ++= Seq("-Xms512M", "-Xmx2048M"),
     scalacOptions ++= Seq("-deprecation", "-unchecked"),
     parallelExecution in Test := false,
     fork := true,


### PR DESCRIPTION
Hi,

I've removed two javaOptions which got the generated project to start using JDK 17 on my machine.

-XX:MaxPermSize was deprecated in JDK 8, which is the version that's being targetted in the -source / -target parameters anyway.
-XX:+CMSClassUnloadingEnabled seems to require UseConcMarkSweepGC to work, which isn't set, and with MetaSpace replacing PermGen classes are garbage collected anyway if I understand correctly?

I think these could be safely removed, and it worked for me to get the generated template to work on my machine.
But since I'm rather new to Scala/Spark, there may be other considerations I'm not aware of, so please let me know if I'm missing anything.

Thanks!

fixes #25 

