### PR TITLE
Bump versions

### DIFF
--- a/src/main/g8/.travis.yml
+++ b/src/main/g8/.travis.yml
@@ -11,7 +11,7 @@ cache:
 jdk:
   - oraclejdk8
 scala:
-  - 2.12.13
+  - 2.13.14
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 sudo: false

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -7,7 +7,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "$organization$",
-      scalaVersion := "2.12.13"
+      scalaVersion := "2.13.14"
     )),
     name := "$name$",
     version := "$version$",
@@ -26,8 +26,8 @@ lazy val root = (project in file(".")).
       "org.apache.spark" %% "spark-streaming" % "$sparkVersion$" % "provided",
       "org.apache.spark" %% "spark-sql" % "$sparkVersion$" % "provided",
 
-      "org.scalatest" %% "scalatest" % "3.2.2" % "test",
-      "org.scalacheck" %% "scalacheck" % "1.15.2" % "test",
+      "org.scalatest" %% "scalatest" % "3.2.18" % "test",
+      "org.scalacheck" %% "scalacheck" % "1.18.0" % "test",
       "com.holdenkarau" %% "spark-testing-base" % "$sparkVersion$_$sparkTestingbaseRelease$" % "test"
     ),
 

--- a/src/main/g8/default.properties
+++ b/src/main/g8/default.properties
@@ -4,6 +4,6 @@ organization=com.example
 package=$organization$.$name;format="norm,word"$
 library=$package$
 version=0.0.1
-sparkVersion=3.3.0
-sparkTestingbaseRelease=1.3.0
+sparkVersion=3.5.1
+sparkTestingbaseRelease=1.5.3
 verbatim=.travis.yml sbt

--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.10.0


### PR DESCRIPTION
Bump versions

- sbt : 1.8.2 -> 1.10.0
- com.holdenkarau:spark-testing-base:test : 3.3.0_1.3.0 -> 3.5.1_1.5.3
- org.apache.spark:spark-sql:provided : 3.3.0 -> 3.5.1
- org.apache.spark:spark-streaming:provided : 3.3.0 -> 3.5.1
- org.scala-lang:scala-library : 2.12.13 -> 2.13.14
- org.scalacheck:scalacheck:test : 1.15.2 -> 1.18.0
- org.scalatest:scalatest:test : 3.2.2 -> 3.2.18
